### PR TITLE
행 식별을 용이하게 하기 위해 table-striped 추가

### DIFF
--- a/garden4-backend/attendance/static/js/common.js
+++ b/garden4-backend/attendance/static/js/common.js
@@ -12,7 +12,7 @@ function get_attendance() {
         data: {}
     }).done(function (data) {
         // console.log(data);
-        let html = `<table class="table table-sm">
+        let html = `<table class="table table-sm table-striped">
 <thead>
 <th>user</th>
 <th>first_ts</th>


### PR DESCRIPTION
표가 가로로 엄청 긴데 모두 하얀 바탕이어서 나의 최근일자 출석내역을 알아보기 힘들어 striped 클래스를 추가했습니다.

적용 예

![Screen Shot 2019-11-06 at 12 04 14 PM](https://user-images.githubusercontent.com/854492/68264851-98abb500-008d-11ea-8550-4f62d28713fc.png)

