### PR TITLE
행 식별을 용이하게 하기 위해 table-hover 추가

### DIFF
--- a/garden4-backend/attendance/static/js/common.js
+++ b/garden4-backend/attendance/static/js/common.js
@@ -12,7 +12,7 @@ function get_attendance() {
         data: {}
     }).done(function (data) {
         // console.log(data);
-        let html = `<table class="table table-sm table-striped">
+        let html = `<table class="table table-sm table-striped table-hover">
 <thead>
 <th>user</th>
 <th>first_ts</th>


### PR DESCRIPTION
.table-hover를 추가하면 마우스 커서가 올라간 행을 하이라이트해주어서 행 식별이 좀더 용이해집니다.